### PR TITLE
`FILESYSTEM_DRIVER`设置为`public`,将运行错误

### DIFF
--- a/src/PartialResource.php
+++ b/src/PartialResource.php
@@ -19,7 +19,7 @@ class PartialResource
 
     public function __construct($tempBaseName, $extension, $groupSubDir)
     {
-        $this->disk = Storage::disk('local');
+        $this->disk = Storage::disk();
         $this->tempName = Util::getFileName($tempBaseName, $extension);
         $this->group = ConfigMapper::get('group');
         $this->groupDir = ConfigMapper::get('group_dir');

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -16,7 +16,7 @@ class Resource
 
     public function __construct($group, $groupDir, $groupSubDir, $name)
     {
-        $this->disk = Storage::disk('local');
+        $this->disk = Storage::disk();
         $this->name = $name;
         $this->group = $group;
         $this->groupDir = $groupDir;


### PR DESCRIPTION
如果将`FILESYSTEM_DRIVER`设置为`public`,将运行错误(也许只是我的错误),

只需删除`construct`中的锁定disk到local代码即可解决