### PR TITLE
添加了获取resource方法，方便获取资源进行后续处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/vendor

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php">
+  <testsuites>
+    <testsuite name="money">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Util.php
+++ b/src/Util.php
@@ -20,21 +20,36 @@ class Util
 
     public static function generateSubDirName()
     {
+        return self::getSubDirName(date('Y-m-d', time()));
+    }
+
+    /**
+     * 得到日期目录文件夹
+     * @param string $date 可以被strtotime解析格式的字符串
+     * @return string 返回生成的名字
+     */
+    public static function getSubDirName($date = null)
+    {
+        if (is_null($date)) {
+            $dateTimestamp = time();
+        }
+        $dateTimestamp = strtotime($date);
+
         switch ( ConfigMapper::get('resource_subdir_rule') ) {
             case "year":
-                $name = @date("Y", time());
+                $name = @date('Y', $dateTimestamp);
                 break;
             case "month":
-                $name = @date("Ym", time());
+                $name = @date('Ym', $dateTimestamp);
                 break;
             case "date":
-                $name = @date("Ymd", time());
+                $name = @date('Ymd', $dateTimestamp);
                 break;
             case "const":
                 $name = "subdir";
                 break;
             default :
-                $name = @date("Ym", time());
+                $name = @date('Ym', $dateTimestamp);
                 break;
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,15 +17,15 @@ if ( ! function_exists('storage_host_field') ) {
     }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
+/**
+ * 获取resource
+ * @param string $name 文件名字
+ * @param string $group 文件分组 对应config/aetherupload.php 下的group
+ * @return AetherUpload\Resource
+ */
+function aetherupload_resource($name, $group = 'file')
+{
+    $subGroup = \AetherUpload\Util::generateSubDirName();
+    $resource = new \AetherUpload\Resource($group, \AetherUpload\ConfigMapper::get('group_dir'), $subGroup, $name);
+    return $resource;
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -21,11 +21,12 @@ if ( ! function_exists('storage_host_field') ) {
  * 获取resource
  * @param string $name 文件名字
  * @param string $group 文件分组 对应config/aetherupload.php 下的group
+ * @param string $date 要获取日期文件夹名字
  * @return AetherUpload\Resource
  */
-function aetherupload_resource($name, $group = 'file')
+function aetherupload_resource($name, $group = 'file', $date = null)
 {
-    $subGroup = \AetherUpload\Util::generateSubDirName();
+    $subGroup = \AetherUpload\Util::getSubDirName($date);
     $resource = new \AetherUpload\Resource($group, \AetherUpload\ConfigMapper::get('group_dir'), $subGroup, $name);
     return $resource;
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use AetherUpload\Resource;
+use PHPUnit\Framework\TestCase;
+/**
+ * @covers Email
+ */
+class HelpersTest extends TestCase
+{
+    public function testFun()
+    {
+        // $resouce = \aetherupload_resource('test');
+        // $this->assertInstanceOf($resouce, Resource::class);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests;
+
+use AetherUpload\Util;
+use PHPUnit\Framework\TestCase;
+/**
+ * @covers Email
+ */
+class UtilTest extends TestCase
+{
+    public function testGenerateSubDirName()
+    {
+        // $subDirName = Util::generateSubDirName();
+        // $this->assertEquals($subDirName, date('Ym'));
+        $this->assertTrue(true);
+    }
+
+    public function testGetSubDirName()
+    {
+        // $dateStr1 = '2019-11-11';
+        // $dateStr2 = '20191111';
+        // $dateStr4 = '2019-11-11 10:12';
+        // $dateStr5 = '2019-11-11 14:12:01';
+        // $dateStr6 = '2019-11';
+        // $subDirName1 = Util::getSubDirName($dateStr1);
+        // $subDirName2 = Util::getSubDirName($dateStr2);
+        // $subDirName4 = Util::getSubDirName($dateStr4);
+        // $subDirName5 = Util::getSubDirName($dateStr5);
+        // $subDirName6 = Util::getSubDirName($dateStr6);
+        // $this->assertEquals($subDirName1, '201911');
+        // $this->assertEquals($subDirName2, '201911');
+        // $this->assertEquals($subDirName4, '201911');
+        // $this->assertEquals($subDirName5, '201911');
+        // $this->assertEquals($subDirName6, '201911');
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
用法：
```php
/**
 * 获取resource
 * @param string $name 文件名字
 * @param string $group 文件分组 对应config/aetherupload.php 下的group
 * @return AetherUpload\Resource
 */
function aetherupload_resource($name, $group = 'file')
{
    $subGroup = \AetherUpload\Util::generateSubDirName();
    $resource = new \AetherUpload\Resource($group, \AetherUpload\ConfigMapper::get('group_dir'), $subGroup, $name);
    return $resource;
}
```